### PR TITLE
Make Assignment Resource Names Idempotent

### DIFF
--- a/sso_automation_app/sso_stack.py
+++ b/sso_automation_app/sso_stack.py
@@ -178,7 +178,7 @@ class AWSSSOStack(Stack):
                     principal_id = v
 
                 self.assign = sso.CfnAssignment(
-                    self, grp_name + "Assignment" + str(count),
+                    self, grp_name + "Assignment" + acct_id,
                     instance_arn=self.ssoinstancearn,
                     permission_set_arn=self.permission_set_arns[item[2]],
                     principal_id=principal_id,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Currently, if the `assignments.json` file has its array changed (e.g., an element is inserted in the middle), it crashes the deployment claiming the resource already exists. To fix the issue, I have removed the counter from the identifier and replaced it with the accound id, making the identifier reliable independently of the order in which an assignment appears in the array.

 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
